### PR TITLE
feat: enhance interpolation to support worker pool and cancellation

### DIFF
--- a/libs/carbon-ext/package.json
+++ b/libs/carbon-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dj-ui/carbon-ext",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "publishConfig": {
     "access": "public"
@@ -15,8 +15,8 @@
     "@angular/router": "~18.2.0",
     "carbon-components-angular": "^5.56.4",
     "lodash-es": "^4.17.21",
-    "@dj-ui/core": "0.2.0",
-    "@dj-ui/common": "0.2.0",
+    "@dj-ui/core": "0.3.0",
+    "@dj-ui/common": "0.3.0",
     "@namnguyen191/types-helper": "1.0.0-1",
     "zod": "^3.23.8"
   },

--- a/libs/common/package.json
+++ b/libs/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dj-ui/common",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "publishConfig": {
     "access": "public"
@@ -15,7 +15,7 @@
     "@angular/router": "~18.2.0",
     "rxjs": "~7.8.1",
     "zod": "^3.23.8",
-    "@dj-ui/core": "0.2.0",
+    "@dj-ui/core": "0.3.0",
     "@namnguyen191/types-helper": "1.0.0-1",
     "lodash-es": "^4.17.21"
   },

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dj-ui/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/libs/core/src/lib/components/layout/ui-element-wrapper/ui-element-wrapper.component.ts
+++ b/libs/core/src/lib/components/layout/ui-element-wrapper/ui-element-wrapper.component.ts
@@ -184,17 +184,17 @@ export class UiElementWrapperComponent {
         : elementInterpolationContext.pipe(
             switchMap((context) => {
               {
-                return from(
-                  this.#interpolationService.interpolate({
+                return this.#interpolationService
+                  .interpolate({
                     context,
                     value: val,
                   })
-                ).pipe(
-                  catchError(() => {
-                    console.warn(`Fail to interpolate ${key}`);
-                    return EMPTY;
-                  })
-                );
+                  .pipe(
+                    catchError((err) => {
+                      console.warn(`Fail to interpolate ${key}. Error: ${err}`);
+                      return EMPTY;
+                    })
+                  );
               }
             })
           );

--- a/libs/core/src/lib/global.ts
+++ b/libs/core/src/lib/global.ts
@@ -8,3 +8,4 @@ export type CoreConfig = {
 };
 export const CORE_CONFIG = new InjectionToken<CoreConfig>('CORE_CONFIG');
 export const CREATE_JS_RUNNER_WORKER = new InjectionToken<() => Worker>('CREATE_JS_RUNNER_WORKER');
+export const MAX_WORKER_POOl = new InjectionToken<number>('MAX_WORKER_POOl');

--- a/libs/core/src/lib/services/state-store.service.ts
+++ b/libs/core/src/lib/services/state-store.service.ts
@@ -4,13 +4,11 @@ import {
   BehaviorSubject,
   combineLatest,
   distinctUntilChanged,
-  from,
   map,
   Observable,
   of,
   pipe,
   switchMap,
-  tap,
   UnaryFunction,
 } from 'rxjs';
 import { UnknownRecord } from 'type-fest';
@@ -87,16 +85,15 @@ export const getStatesSubscriptionAsContext = (
         return of({ ...state });
       }
 
-      return from(
-        interpolationService.interpolate({
+      return interpolationService
+        .interpolate({
           value: variables,
           context: {
             state,
           },
         })
-      ).pipe(map((interpolatedVariables) => ({ ...state, variables: interpolatedVariables })));
-    }),
-    tap((val) => console.log('Nam data is: result', val))
+        .pipe(map((interpolatedVariables) => ({ ...state, variables: interpolatedVariables })));
+    })
   );
 };
 


### PR DESCRIPTION
- Interpolation will now use a pool of different workers instead of posting all msg to the same worker
- Allow an on-going interpolation to be cancelled, which will terminate the worker, preventing a single bad interpolation to freeze the entire process