### PR TITLE
feat: add interpolation as a part of ui element state

### DIFF
--- a/libs/core/src/lib/components/base-ui-element.component.ts
+++ b/libs/core/src/lib/components/base-ui-element.component.ts
@@ -18,6 +18,10 @@ export const ZodIsError = z.boolean({
 });
 
 export type UIElementRequiredConfigs = {
+  isInterpolationLoading: boolean;
+  isInterpolationError: boolean;
+  isResourceLoading: boolean;
+  isResourceError: boolean;
   isLoading: boolean;
   isError: boolean;
 };
@@ -72,6 +76,26 @@ export abstract class BaseUIElementComponent
 
   isLoadingConfigOption: InputSignal<boolean> = input(false, {
     alias: 'isLoading',
+    transform: (val) => ZodIsLoading.parse(val),
+  });
+
+  isResourceLoadingConfigOption: InputSignal<boolean> = input(false, {
+    alias: 'isResourceLoading',
+    transform: (val) => ZodIsError.parse(val),
+  });
+
+  isResourceErrorConfigOption: InputSignal<boolean> = input(false, {
+    alias: 'isResourceError',
+    transform: (val) => ZodIsLoading.parse(val),
+  });
+
+  isInterpolationLoadingConfigOption: InputSignal<boolean> = input(false, {
+    alias: 'isInterpolationLoading',
+    transform: (val) => ZodIsError.parse(val),
+  });
+
+  isInterpolationErrorConfigOption: InputSignal<boolean> = input(false, {
+    alias: 'isInterpolationError',
     transform: (val) => ZodIsLoading.parse(val),
   });
 }


### PR DESCRIPTION
Interpolation will now be a part of ui element state. We will track when interpolation is running and when there are errors. The option `isLoading` and `isError` will no longer point to just remote resource state as they have been separated in to `isRemoteResourceLoading` and `isRemoteResourceError`, instead, they are now the general state for both remote resource and interpolation