### PR TITLE
fix: extra wrapper, hooks and img sliders bugs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,19 @@ import eslintPluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
 import jsonParser from 'jsonc-eslint-parser';
 import tseslint from 'typescript-eslint';
 
+export const depsCheckIgnoredList = [
+  '@nx/devkit',
+  'vite',
+  '@analogjs/vite-plugin-angular',
+  '@nx/vite',
+  '@angular/compiler',
+  'zod-to-json-schema',
+  '@analogjs/vitest-angular',
+  '@angular/platform-browser',
+  'type-fest',
+  'jsonc-eslint-parser',
+];
+
 export default tseslint.config([
   {
     ignores: [
@@ -159,17 +172,7 @@ export default tseslint.config([
       '@nx/dependency-checks': [
         'error',
         {
-          ignoredDependencies: [
-            '@nx/devkit',
-            'vite',
-            '@analogjs/vite-plugin-angular',
-            '@nx/vite',
-            '@angular/compiler',
-            'zod-to-json-schema',
-            '@analogjs/vitest-angular',
-            '@angular/platform-browser',
-            'type-fest',
-          ],
+          ignoredDependencies: depsCheckIgnoredList,
         },
       ],
     },

--- a/libs/common/src/lib/core-setup-helpers.ts
+++ b/libs/common/src/lib/core-setup-helpers.ts
@@ -14,7 +14,7 @@ import {
 } from '@dj-ui/common/shared';
 import type { Template } from '@dj-ui/core';
 import {
-  type ActionHookHandlerAndPayloadParserMap,
+  type ActionHookHandlerAndParserMap,
   ActionHookService,
   DataFetchingService,
   ELEMENT_RENDERER_CONFIG,
@@ -49,7 +49,7 @@ export const registerDefaultHook = (): void => {
   const defaultActionsHooksService = inject(DefaultActionsHooksService);
   const actionHookService = inject(ActionHookService);
 
-  const actionHookHandlerAndPayloadParserMap: ActionHookHandlerAndPayloadParserMap = {
+  const ActionHookHandlerAndParserMap: ActionHookHandlerAndParserMap = {
     addToState: {
       handler: defaultActionsHooksService.handleAddToState,
       actionHookSchema: ZAddToStateActionHook,
@@ -64,7 +64,7 @@ export const registerDefaultHook = (): void => {
     },
   };
 
-  actionHookService.registerHooks(actionHookHandlerAndPayloadParserMap);
+  actionHookService.registerHooks(ActionHookHandlerAndParserMap);
 };
 
 export const registerSimpleHttpDataFetcher = (): void => {

--- a/libs/core/src/lib/directives/ui-element-renderer-directive/ui-element-renderer-directive.ts
+++ b/libs/core/src/lib/directives/ui-element-renderer-directive/ui-element-renderer-directive.ts
@@ -84,9 +84,9 @@ export class UIElementRendererDirective extends BaseUIElementRendererDirective {
         uiElementWrapperComponent.setInput('uiElementComponentRef', createdUIElementComponent);
 
         componentRef = createdUIElementComponent;
+      } else {
+        componentRef = this.viewContainerRef.createComponent(uiElementComp);
       }
-
-      componentRef = this.viewContainerRef.createComponent(uiElementComp);
 
       for (const [inputName, inputVal] of Object.entries(requiredInputs)) {
         componentRef.setInput(inputName, inputVal);

--- a/libs/core/src/lib/services/events-and-actions/action-hook.service.ts
+++ b/libs/core/src/lib/services/events-and-actions/action-hook.service.ts
@@ -13,7 +13,7 @@ export const ZGenericActionHook = z.strictObject({
 
 export type ActionHookHandler<T extends ActionHook['payload']> = (payload: T) => void;
 
-export type ActionHookHandlerAndPayloadParserMap = {
+export type ActionHookHandlerAndParserMap = {
   [hookId: string]: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handler: ActionHookHandler<any>;
@@ -25,7 +25,7 @@ export type ActionHookHandlerAndPayloadParserMap = {
   providedIn: 'root',
 })
 export class ActionHookService {
-  #actionHookHandlerAndPayloadParserMap: ActionHookHandlerAndPayloadParserMap = {};
+  #ActionHookHandlerAndParserMap: ActionHookHandlerAndParserMap = {};
 
   registerHook<T extends ActionHook['payload'] = never>(params: {
     hookId: string;
@@ -33,18 +33,18 @@ export class ActionHookService {
     actionHookSchema?: z.ZodType<ActionHook>;
   }): void {
     const { hookId, handler, actionHookSchema } = params;
-    const existing = this.#actionHookHandlerAndPayloadParserMap[hookId];
+    const existing = this.#ActionHookHandlerAndParserMap[hookId];
     if (existing) {
       console.warn(`The hook ${hookId} has already existed. Registering it again will override it`);
     }
 
-    this.#actionHookHandlerAndPayloadParserMap[hookId] = {
+    this.#ActionHookHandlerAndParserMap[hookId] = {
       handler,
       actionHookSchema,
     };
   }
 
-  registerHooks(handlersAndParsersMap: ActionHookHandlerAndPayloadParserMap): void {
+  registerHooks(handlersAndParsersMap: ActionHookHandlerAndParserMap): void {
     Object.entries(handlersAndParsersMap).forEach(([hookId, { handler, actionHookSchema }]) => {
       this.registerHook({
         hookId,
@@ -55,18 +55,17 @@ export class ActionHookService {
   }
 
   triggerActionHook(hook: ActionHook): void {
-    const handler = this.#actionHookHandlerAndPayloadParserMap[hook.type]?.handler;
+    const handler = this.#ActionHookHandlerAndParserMap[hook.type]?.handler;
     if (!handler) {
       console.warn(`No handler for hook ${hook.type}`);
 
       return;
     }
 
-    const actionHookSchema =
-      this.#actionHookHandlerAndPayloadParserMap[hook.type]?.actionHookSchema;
+    const actionHookSchema = this.#ActionHookHandlerAndParserMap[hook.type]?.actionHookSchema;
     if (actionHookSchema) {
       try {
-        actionHookSchema.parse(hook.payload);
+        actionHookSchema.parse(hook);
       } catch (error) {
         if (error instanceof z.ZodError) {
           console.warn(

--- a/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-body.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-body.directive.ts
@@ -1,10 +1,15 @@
 import '@carbon/web-components/es/components/data-table/table-body.js';
 
-import { Directive } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import type CDSTableBody from '@carbon/web-components/es/components/data-table/table-body.js';
-import { CDSBaseDirective } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
+import { CDSBaseDirective, type CDSDirectiveImpl } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
 
 @Directive({
   selector: 'cds-table-body',
 })
-export class CDSTableBodyDirective extends CDSBaseDirective<CDSTableBody> {}
+export class CDSTableBodyDirective
+  extends CDSBaseDirective<CDSTableBody>
+  implements CDSDirectiveImpl<CDSTableBody>
+{
+  useZebraStyles = input<boolean>();
+}

--- a/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-cell.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-cell.directive.ts
@@ -1,10 +1,16 @@
 import '@carbon/web-components/es/components/data-table/table-cell.js';
 
-import { Directive } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import type CDSTableCell from '@carbon/web-components/es/components/data-table/table-cell.js';
-import { CDSBaseDirective } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
+import { CDSBaseDirective, type CDSDirectiveImpl } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
 
 @Directive({
   selector: 'cds-table-cell',
 })
-export class CDSTableCellDirective extends CDSBaseDirective<CDSTableCell> {}
+export class CDSTableCellDirective
+  extends CDSBaseDirective<CDSTableCell>
+  implements CDSDirectiveImpl<CDSTableCell>
+{
+  overflowMenuOnHover = input<boolean>();
+  size = input<unknown>();
+}

--- a/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-head.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-head.directive.ts
@@ -2,9 +2,11 @@ import '@carbon/web-components/es/components/data-table/table-head.js';
 
 import { Directive } from '@angular/core';
 import type CDSTableHead from '@carbon/web-components/es/components/data-table/table-head.js';
-import { CDSBaseDirective } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
+import { CDSBaseDirective, type CDSDirectiveImpl } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
 
 @Directive({
   selector: 'cds-table-head',
 })
-export class CDSTableHeadDirective extends CDSBaseDirective<CDSTableHead> {}
+export class CDSTableHeadDirective
+  extends CDSBaseDirective<CDSTableHead>
+  implements CDSDirectiveImpl<CDSTableHead> {}

--- a/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-header-cell.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-header-cell.directive.ts
@@ -1,10 +1,25 @@
 import '@carbon/web-components/es/components/data-table/table-header-cell.js';
 
-import { Directive } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import type CDSTableHeaderCell from '@carbon/web-components/es/components/data-table/table-header-cell.js';
-import { CDSBaseDirective } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
+import {
+  CDSBaseDirective,
+  type CDSDirectiveImpl,
+  type TableSortCycle,
+  type TableSortDirection,
+} from '@dj-ui/ng-carbon-wcmp-bridge/shared';
 
 @Directive({
   selector: 'cds-table-header-cell',
 })
-export class CDSTableHeaderCellDirective extends CDSBaseDirective<CDSTableHeaderCell> {}
+export class CDSTableHeaderCellDirective
+  extends CDSBaseDirective<CDSTableHeaderCell>
+  implements CDSDirectiveImpl<CDSTableHeaderCell>
+{
+  isExpandable = input<boolean>();
+  isSelectable = input<boolean>();
+  isSortable = input<boolean>();
+  sortActive = input<boolean>();
+  sortCycle = input<TableSortCycle>();
+  sortDirection = input<TableSortDirection>();
+}

--- a/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-header-row.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-header-row.directive.ts
@@ -1,10 +1,29 @@
 import '@carbon/web-components/es/components/data-table/table-header-row.js';
 
-import { Directive } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import type CDSTableHeaderRow from '@carbon/web-components/es/components/data-table/table-header-row.js';
-import { CDSBaseDirective } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
+import { CDSBaseDirective, type CDSDirectiveImpl } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
 
 @Directive({
   selector: 'cds-table-header-row',
 })
-export class CDSTableHeaderRowDirective extends CDSBaseDirective<CDSTableHeaderRow> {}
+export class CDSTableHeaderRowDirective
+  extends CDSBaseDirective<CDSTableHeaderRow>
+  implements CDSDirectiveImpl<CDSTableHeaderRow>
+{
+  batchExpansion = input<boolean>();
+  disabled = input<boolean>();
+  even = input<boolean>();
+  expandable = input<boolean>();
+  expanded = input<boolean>();
+  filtered = input<boolean>();
+  hideCheckbox = input<boolean>();
+  highlighted = input<boolean>();
+  odd = input<boolean>();
+  overflowMenuOnHover = input<boolean>();
+  radio = input<boolean>();
+  selected = input<boolean>();
+  selectionLabel = input<string>();
+  selectionName = input<string>();
+  selectionValue = input<string>();
+}

--- a/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-row.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table-row.directive.ts
@@ -1,10 +1,29 @@
 import '@carbon/web-components/es/components/data-table/table-row.js';
 
-import { Directive } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import type CDSTableRow from '@carbon/web-components/es/components/data-table/table-row.js';
-import { CDSBaseDirective } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
+import { CDSBaseDirective, type CDSDirectiveImpl } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
 
 @Directive({
   selector: 'cds-table-row',
 })
-export class CDSTableRowDirective extends CDSBaseDirective<CDSTableRow> {}
+export class CDSTableRowDirective
+  extends CDSBaseDirective<CDSTableRow>
+  implements CDSDirectiveImpl<CDSTableRow>
+{
+  batchExpansion = input<boolean>();
+  disabled = input<boolean>();
+  even = input<boolean>();
+  expandable = input<boolean>();
+  expanded = input<boolean>();
+  filtered = input<boolean>();
+  hideCheckbox = input<boolean>();
+  highlighted = input<boolean>();
+  odd = input<boolean>();
+  overflowMenuOnHover = input<boolean>();
+  radio = input<boolean>();
+  selected = input<boolean>();
+  selectionLabel = input<string>();
+  selectionName = input<string>();
+  selectionValue = input<string>();
+}

--- a/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/data-table/src/lib/table.directive.ts
@@ -2,11 +2,32 @@ import '@carbon/web-components/es/components/data-table/table.js';
 
 import { Directive, input } from '@angular/core';
 import type CDSTable from '@carbon/web-components/es/components/data-table/table.js';
-import { CDSBaseDirective } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
+import {
+  CDSBaseDirective,
+  type CDSDirectiveImpl,
+  type TableSize,
+} from '@dj-ui/ng-carbon-wcmp-bridge/shared';
 
 @Directive({
   selector: 'cds-table',
 })
-export class CDSTableDirective extends CDSBaseDirective<CDSTable> {
+export class CDSTableDirective
+  extends CDSBaseDirective<CDSTable>
+  implements CDSDirectiveImpl<CDSTable>
+{
+  radio = input<boolean>();
+  collator = input<unknown>();
+  expandable = input<boolean>();
+  headerCount = input<number>();
+  isSelectable = input<boolean>();
+  isSortable = input<boolean>();
+  locale = input<string>();
+  overflowMenuOnHover = input<boolean>();
+  size = input<TableSize>();
+  useStaticWidth = input<boolean>();
+  useZebraStyles = input<boolean>();
+  withHeader = input<boolean>();
+  withRowAILabels = input<boolean>();
+  withRowSlugs = input<boolean>();
   batchExpansion = input<boolean>();
 }

--- a/libs/ng-carbon-wcmp-bridge/eslint.config.mjs
+++ b/libs/ng-carbon-wcmp-bridge/eslint.config.mjs
@@ -1,3 +1,19 @@
 import baseAngularConfig from '../../eslint-angular.config.mjs';
+import { depsCheckIgnoredList } from '../../eslint.config.mjs';
+import jsonParser from 'jsonc-eslint-parser';
 
-export default [...baseAngularConfig];
+export default [
+  ...baseAngularConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredDependencies: [...depsCheckIgnoredList, 'lit'],
+        },
+      ],
+    },
+    languageOptions: { parser: jsonParser },
+  },
+];

--- a/libs/ng-carbon-wcmp-bridge/modal/src/lib/modal-body-content.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/modal/src/lib/modal-body-content.directive.ts
@@ -2,9 +2,11 @@ import '@carbon/web-components/es/components/modal/modal-body-content.js';
 
 import { Directive } from '@angular/core';
 import type CDSModalBodyContent from '@carbon/web-components/es/components/modal/modal-body-content.js';
-import { CDSBaseDirective } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
+import { CDSBaseDirective, type CDSDirectiveImpl } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
 
 @Directive({
   selector: 'cds-modal-body-content',
 })
-export class CDSModalBodyContentDirective extends CDSBaseDirective<CDSModalBodyContent> {}
+export class CDSModalBodyContentDirective
+  extends CDSBaseDirective<CDSModalBodyContent>
+  implements CDSDirectiveImpl<CDSModalBodyContent> {}

--- a/libs/ng-carbon-wcmp-bridge/modal/src/lib/modal-body.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/modal/src/lib/modal-body.directive.ts
@@ -2,9 +2,11 @@ import '@carbon/web-components/es/components/modal/modal-body.js';
 
 import { Directive } from '@angular/core';
 import type CDSModalBody from '@carbon/web-components/es/components/modal/modal-body.js';
-import { CDSBaseDirective } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
+import { CDSBaseDirective, type CDSDirectiveImpl } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
 
 @Directive({
   selector: 'cds-modal-body',
 })
-export class CDSModalBodyDirective extends CDSBaseDirective<CDSModalBody> {}
+export class CDSModalBodyDirective
+  extends CDSBaseDirective<CDSModalBody>
+  implements CDSDirectiveImpl<CDSModalBody> {}

--- a/libs/ng-carbon-wcmp-bridge/modal/src/lib/modal.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/modal/src/lib/modal.directive.ts
@@ -2,12 +2,27 @@ import '@carbon/web-components/es/components/modal/modal.js';
 
 import { Directive, input, output } from '@angular/core';
 import type CDSModal from '@carbon/web-components/es/components/modal/modal.js';
-import { CDSBaseDirective, type ModalBeingClosedEvent } from '@dj-ui/ng-carbon-wcmp-bridge/shared';
+import {
+  CDSBaseDirective,
+  type CDSDirectiveImpl,
+  type ModalBeingClosedEvent,
+  type ModalSize,
+} from '@dj-ui/ng-carbon-wcmp-bridge/shared';
 
 @Directive({
   selector: 'cds-modal',
 })
-export class CDSModalDirective extends CDSBaseDirective<CDSModal> {
+export class CDSModalDirective
+  extends CDSBaseDirective<CDSModal>
+  implements CDSDirectiveImpl<CDSModal>
+{
+  alert = input<boolean>();
+  containerClass = input<string>();
+  fullWidth = input<boolean>();
+  hasScrollingContent = input<boolean>();
+  size = input<ModalSize>();
+  preventCloseOnClickOutside = input<boolean>();
+  preventClose = input<boolean>();
   open = input<boolean>();
 
   'cds-modal-beingclosed' = output<ModalBeingClosedEvent>();

--- a/libs/ng-carbon-wcmp-bridge/shared/src/lib/cds-base.directive.ts
+++ b/libs/ng-carbon-wcmp-bridge/shared/src/lib/cds-base.directive.ts
@@ -1,6 +1,29 @@
-import { Directive, ElementRef, inject, type OnChanges, type SimpleChanges } from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  inject,
+  type InputSignal,
+  type OnChanges,
+  type SimpleChanges,
+} from '@angular/core';
+import type { LitElement } from 'lit';
 
-type UnknownCustomElement = HTMLElement & Record<string, unknown>;
+export type UnknownCustomElement = HTMLElement & Record<string, unknown>;
+
+export type WCProperties<T extends LitElement> = Omit<
+  {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    [K in keyof T as T[K] extends Function ? never : K extends `_${string}` ? never : K]: T[K];
+  },
+  keyof LitElement
+>;
+
+export type CDSDirectiveImpl<TWC extends LitElement, TProp = WCProperties<TWC>> = {
+  [K in keyof TProp]: InputSignal<
+    | (Exclude<TProp[K], undefined> extends string ? `${Exclude<TProp[K], undefined>}` : TProp[K])
+    | undefined
+  >;
+};
 
 @Directive()
 export abstract class CDSBaseDirective<T extends HTMLElement = UnknownCustomElement>

--- a/libs/ng-carbon-wcmp-bridge/shared/src/lib/types.ts
+++ b/libs/ng-carbon-wcmp-bridge/shared/src/lib/types.ts
@@ -1,1 +1,13 @@
+import type { TABLE_SIZE } from '@carbon/web-components/es/components/data-table/table.js';
+import type {
+  TABLE_SORT_CYCLE,
+  TABLE_SORT_DIRECTION,
+} from '@carbon/web-components/es/components/data-table/table-header-cell.js';
+import type { MODAL_SIZE } from '@carbon/web-components/es/components/modal/defs.js';
+
+export type ModalSize = `${MODAL_SIZE}`;
 export type ModalBeingClosedEvent = CustomEvent<{ triggeredBy: HTMLElement }>;
+
+export type TableSize = `${TABLE_SIZE}`;
+export type TableSortCycle = `${TABLE_SORT_CYCLE}`;
+export type TableSortDirection = `${TABLE_SORT_DIRECTION}`;

--- a/libs/prime-ng-ext/images-carousel/src/lib/images-carousel.component.html
+++ b/libs/prime-ng-ext/images-carousel/src/lib/images-carousel.component.html
@@ -45,6 +45,7 @@
   [draggable]="false"
   [modal]="true"
   [resizable]="false"
+  [style]="{ 'max-height': 'unset' }"
   [visible]="!!currentPreviewImageSig()"
   (visibleChange)="closeCurrentPreviewImage()"
 >

--- a/libs/prime-ng-ext/images-carousel/src/lib/images-carousel.component.scss
+++ b/libs/prime-ng-ext/images-carousel/src/lib/images-carousel.component.scss
@@ -71,7 +71,7 @@
   }
 
   .preview-image {
-    width: 60vw;
-    height: 50vh;
+    width: 75vw;
+    height: 75vh;
   }
 }

--- a/libs/prime-ng-ext/simple-image/src/lib/simple-image.component.html
+++ b/libs/prime-ng-ext/simple-image/src/lib/simple-image.component.html
@@ -4,7 +4,6 @@
   <span>Something went wrong</span>
 } @else {
   <img
-    class="slides-container__slide__snapper"
     fill
     [alt]="altLabelConfigOption()"
     [ngSrc]="imageUrlConfigOption()"

--- a/libs/prime-ng-ext/simple-image/src/lib/simple-image.component.scss
+++ b/libs/prime-ng-ext/simple-image/src/lib/simple-image.component.scss
@@ -3,9 +3,4 @@
   height: 100%;
   max-width: 100%;
   position: relative;
-
-  img {
-    object-fit: fill;
-    object-position: center;
-  }
 }

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "jsdom": "26.1.0",
     "jsonc-eslint-parser": "2.4.0",
     "lint-staged": "16.1.2 ",
+    "lit": "^3.3.1",
     "madge": "8.0.0",
     "ng-packagr": "20.1.0",
     "nx": "21.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       lint-staged:
         specifier: '16.1.2 '
         version: 16.1.2
+      lit:
+        specifier: ^3.3.1
+        version: 3.3.1
       madge:
         specifier: 8.0.0
         version: 8.0.0(typescript@5.8.3)


### PR DESCRIPTION
- Extra wrapper no longer create duplicated element
- Action hooks now parse the entire hook object instead of just the payload
- Image carousel preview mode now expand to the set height
- Add some interfaces for carbon web component